### PR TITLE
fix typo: jobid => job_id

### DIFF
--- a/util/proxy/rstudio.js
+++ b/util/proxy/rstudio.js
@@ -16,7 +16,7 @@ module.exports = function ({
 
   return Object.assign({}, proxyConfiguration, {
     pathRewrite: {
-      [`^/${jobid}`]: '/'
+      [`^/${job_id}`]: '/'
     },
     onProxyRes: onProxyRes
   });


### PR DESCRIPTION
https://github.com/hmdc/cas-app-proxy/tree/427-authenticate-access-to-jobs
https://github.com/hmdc/sid/issues/459
https://github.com/hmdc/sid/issues/427

@whorka and I are running into this error:

```
./util/proxy/rstudio.js:25
      [`^/${jobid}`]: '/'
            ^

ReferenceError: jobid is not defined
    at module.exports (./util/proxy/rstudio.js:25:13)
    at module.exports (./util/proxy.js:18:45)
    at ./app.js:58:20
    at Object.<anonymous> (./app.js:78:3)
    at Module._compile (internal/modules/cjs/loader.js:738:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:749:10)
    at Module.load (internal/modules/cjs/loader.js:630:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:570:12)
    at Function.Module._load (internal/modules/cjs/loader.js:562:3)
    at Module.require (internal/modules/cjs/loader.js:667:17)
```